### PR TITLE
add official stable support for drupal 10.4 & 11.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '11.0']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['factory_lollipop']
         experimental: [false]
         include:
-          - drupal_version: '11.1'
+          - drupal_version: '10.5'
+            module: 'factory_lollipop'
+            experimental: true
+          - drupal_version: '11.2'
             module: 'factory_lollipop'
             experimental: true
 
@@ -43,11 +46,14 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '11.0']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['factory_lollipop']
         experimental: [ false ]
         include:
-          - drupal_version: '11.1'
+          - drupal_version: '10.5'
+            module: 'factory_lollipop'
+            experimental: true
+          - drupal_version: '11.2'
             module: 'factory_lollipop'
             experimental: true
 
@@ -76,7 +82,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5']
+        drupal_version: ['10.4']
         module: ['factory_lollipop']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add official stable support of drupal 10.4
+- add official stable support of drupal 11.1
 
 ## [1.2.2] - 2024-08-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add official stable support of drupal 10.4
 - add official stable support of drupal 11.1
 
+### Fixed
+- fix wrong @covers in order to calm-down phpstan
+
 ## [1.2.2] - 2024-08-20
 ### Fixed
 - fix obsolete docker-compose command in CIs

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Factory Lollipop is available for both Drupal 9, Drupal 10 & Drupal 11 (dev) !
 |     9.0     |      1.0.0       |
 |     9.x     |      1.1.x       |
 |    10.x     |      1.2.x       |
-|  11.x-dev   |      1.2.x       |
+|    11.x     |      1.2.x       |
 
 ## Roadmap
 

--- a/modules/factory_lollipop_paragraphs/factory_lollipop_paragraphs.info.yml
+++ b/modules/factory_lollipop_paragraphs/factory_lollipop_paragraphs.info.yml
@@ -2,7 +2,7 @@ name: Factory Lollipop - Paragraphs
 type: module
 description: 'Provides the utility APIs for using the factory pattern with Paragraphs.'
 package: Development
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^9.5 || ^10 || ^11
 dependencies:
   - factory_lollipop:factory_lollipop
   - paragraphs:paragraphs

--- a/modules/factory_lollipop_paragraphs/tests/modules/factory_lollipop_paragraphs_test/factory_lollipop_paragraphs_test.info.yml
+++ b/modules/factory_lollipop_paragraphs/tests/modules/factory_lollipop_paragraphs_test/factory_lollipop_paragraphs_test.info.yml
@@ -2,7 +2,7 @@ name: Factory Lollipop Test - Paragraphs
 type: module
 description: Contains various example of Factory Lollipop usage with Paragraphs.
 package: Testing
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.5 || ^10 || ^11
 
 dependencies:
   - factory_lollipop:factory_lollipop_paragraphs

--- a/modules/factory_lollipop_paragraphs/tests/modules/factory_lollipop_paragraphs_test/tests/src/Kernel/ParagraphFactoryTest.php
+++ b/modules/factory_lollipop_paragraphs/tests/modules/factory_lollipop_paragraphs_test/tests/src/Kernel/ParagraphFactoryTest.php
@@ -70,7 +70,7 @@ class ParagraphFactoryTest extends LollipopKernelTestBase {
    * @covers \Drupal\factory_lollipop\FixtureFactory::define
    * @covers \Drupal\factory_lollipop\FixtureFactory::association
    * @covers \Drupal\factory_lollipop\FixtureFactory::create
-   * @covers \Drupal\factory_lollipop\FactoryType\ParagraphFactoryType::create
+   * @covers \Drupal\factory_lollipop_paragraphs\FactoryType\ParagraphFactoryType::create
    */
   public function testDefineOverride() {
     $this->factoryLollipop->loadDefinitions(['paragraph_accordion']);


### PR DESCRIPTION
### 💬 Description
add official stable support for drupal 10.4 & 11.1

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
