### PR TITLE
drop support of Drupal 9.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['factory_lollipop']
         experimental: [false]
         include:
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['factory_lollipop']
         experimental: [ false ]
         include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,14 +32,12 @@ variables:
   SKIP_ESLINT: '1'
   # Opt in to testing current minor against max supported PHP version.
   OPT_IN_TEST_MAX_PHP: '1'
-  # Opt in to testing previous & next minor (Drupal 10.1.x and 10.3.x).
+  # Opt in to testing previous minor (Drupal 11.0.3) & next minor (Drupal 11.2-dev).
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
   OPT_IN_TEST_NEXT_MINOR: '1'
-  # Opt in to testing $CORE_PREVIOUS_MAJOR (currently Drupal 9.5).
+  # Opt in to testing $CORE_PREVIOUS_MAJOR (currently Drupal 10.4.6).
   OPT_IN_TEST_PREVIOUS_MAJOR: '1'
-  # The current branch of the module requires PHP >=8.1 minimum.
-  CORE_PREVIOUS_PHP_MIN: '8.1'
-  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (currently Drupal 11).
+  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (currently Drupal 12).
   OPT_IN_TEST_NEXT_MAJOR: '1'
 
 # This module wants to strictly comply with Drupal's coding standards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - drop support of Drupal 9.x
+- remove scanning CSS/JS with phpcs (deprecated and support will be removed in PHP_CodeSniffer 4.0)
 
 ## [1.2.2] - 2024-08-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - fix wrong @covers in order to calm-down phpstan
 
+### Removed
+- drop support of Drupal 9.x
+
 ## [1.2.2] - 2024-08-20
 ### Fixed
 - fix obsolete docker-compose command in CIs

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ It may be useful for existing users to check out the [upgrade guide](UPGRADING.m
 
 ## Versions
 
-Factory Lollipop is available for both Drupal 9, Drupal 10 & Drupal 11 (dev) !
+Factory Lollipop is available for both Drupal 9, Drupal 10 & Drupal 11 !
 
 ### Which version should I use?
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
       "url": "https://packages.drupal.org/8"
     }
   ],
-  "minimum-stability": "dev",
   "support": {
     "issues": "https://www.drupal.org/project/issues/factory_lollipop"
   },

--- a/factory_lollipop.info.yml
+++ b/factory_lollipop.info.yml
@@ -2,6 +2,6 @@ name: Factory Lollipop
 description: 'Factory Lollipop is a comprehensive solution for using the factory pattern to generate short-lived test data-structure.'
 package: 'Development'
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:user

--- a/modules/factory_lollipop_paragraphs/factory_lollipop_paragraphs.info.yml
+++ b/modules/factory_lollipop_paragraphs/factory_lollipop_paragraphs.info.yml
@@ -2,7 +2,7 @@ name: Factory Lollipop - Paragraphs
 type: module
 description: 'Provides the utility APIs for using the factory pattern with Paragraphs.'
 package: Development
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 dependencies:
   - factory_lollipop:factory_lollipop
   - paragraphs:paragraphs

--- a/modules/factory_lollipop_paragraphs/tests/modules/factory_lollipop_paragraphs_test/factory_lollipop_paragraphs_test.info.yml
+++ b/modules/factory_lollipop_paragraphs/tests/modules/factory_lollipop_paragraphs_test/factory_lollipop_paragraphs_test.info.yml
@@ -2,7 +2,7 @@ name: Factory Lollipop Test - Paragraphs
 type: module
 description: Contains various example of Factory Lollipop usage with Paragraphs.
 package: Testing
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - factory_lollipop:factory_lollipop_paragraphs

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,7 +6,7 @@
   <arg name="basepath" value="."/>
   <arg name="cache" value=".phpcs-cache"/>
   <arg name="colors"/>
-  <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt"/>
+  <arg name="extensions" value="php,inc,module,install,info,test,profile,theme"/>
 
   <exclude-pattern>*\.(md|info\.yml)$</exclude-pattern>>
   <exclude-pattern>*/vendor/*</exclude-pattern>>

--- a/tests/modules/factory_lollipop_test/factory_lollipop_test.info.yml
+++ b/tests/modules/factory_lollipop_test/factory_lollipop_test.info.yml
@@ -2,7 +2,7 @@ name: Factory Lollipop Test
 type: module
 description: Contains various example of Factory Lollipop usage.
 package: Testing
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - factory_lollipop:factory_lollipop


### PR DESCRIPTION
### 💬 Description
drop support of Drupal 9.x

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
