### PR TITLE
remove legacy 'version_compare' from Tests suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - drop coverage of Drupal 10.2.x
 - drop coverage of Drupal 10.3.x
 - drop coverage of Drupal 10.4.x
+- remove legacy 'version_compare' from Tests suites
 
 ## [1.2.3] - 2025-05-15
 ### Added

--- a/tests/src/Functional/HelpTest.php
+++ b/tests/src/Functional/HelpTest.php
@@ -43,15 +43,8 @@ class HelpTest extends BrowserTestBase {
 
     $permissions = [
       'access administration pages',
+      'access help pages',
     ];
-
-    // Since Drupal 10.2 accessing help page require a new permission.
-    if (version_compare(\Drupal::VERSION, '10.2', '>=')) {
-      $permissions = [
-        'access administration pages',
-        'access help pages',
-      ];
-    }
 
     // Create users.
     $this->adminUser = $this->drupalCreateUser($permissions);

--- a/tests/src/Functional/InstallUninstallTest.php
+++ b/tests/src/Functional/InstallUninstallTest.php
@@ -30,13 +30,7 @@ class InstallUninstallTest extends ModuleTestBase {
     $this->drupalGet('admin/modules');
     $this->submitForm($edit, 'Install');
 
-    // Since Drupal 10.3 the installation message has been changed.
-    if (version_compare(\Drupal::VERSION, '10.3', '>=')) {
-      $this->assertSession()->pageTextContains('Module Factory Lollipop has been installed.');
-    }
-    else {
-      $this->assertSession()->pageTextContains('Module Factory Lollipop has been enabled');
-    }
+    $this->assertSession()->pageTextContains('Module Factory Lollipop has been installed.');
 
     // Makes sure the module has been installed.
     $this->assertModules(['factory_lollipop'], TRUE);


### PR DESCRIPTION
### 💬 Description
remove legacy 'version_compare' from Tests suites

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
