### PR TITLE
fix Phpcs documentation comment contains forbidden comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - drop coverage of Drupal 10.4.x
 - remove legacy 'version_compare' from Tests suites
 
+### Fixed
+- fix Phpcs documentation comment contains forbidden comment
+
 ## [1.2.3] - 2025-05-15
 ### Added
 - add official stable support of drupal 10.4

--- a/tests/modules/factory_lollipop_test/tests/src/Kernel/NodeFieldFactoryTest.php
+++ b/tests/modules/factory_lollipop_test/tests/src/Kernel/NodeFieldFactoryTest.php
@@ -22,7 +22,7 @@ class NodeFieldFactoryTest extends LollipopKernelTestBase {
   ];
 
   /**
-   * Ensure defined Node-Field associated to Node can be created with fields..
+   * Ensure defined Node-Field associated to Node can be created with fields.
    *
    * @covers \Drupal\factory_lollipop\FixtureFactory::loadDefinitions
    * @covers \Drupal\factory_lollipop\FixtureFactory::define


### PR DESCRIPTION
### 💬 Description
fix Phpcs documentation comment contains forbidden comment

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
