### PR TITLE
add official support of drupal 10.6 & 11.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,19 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5', '11.0', '11.1']
+        drupal_version: ['10.5', '10.6', '11.0', '11.1', '11.2', '11.3']
         module: ['factory_lollipop']
         experimental: [false]
-        include:
-          - drupal_version: '10.6'
-            module: 'factory_lollipop'
-            experimental: true
-          - drupal_version: '11.2'
-            module: 'factory_lollipop'
-            experimental: true
-          - drupal_version: '11.3'
-            module: 'factory_lollipop'
-            experimental: true
+#         include:
+#           - drupal_version: '10.6'
+#             module: 'factory_lollipop'
+#             experimental: true
+#           - drupal_version: '11.2'
+#             module: 'factory_lollipop'
+#             experimental: true
+#           - drupal_version: '11.3'
+#             module: 'factory_lollipop'
+#             experimental: true
 
     steps:
       - uses: actions/checkout@v6
@@ -49,19 +49,19 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5', '11.0', '11.1']
+        drupal_version: ['10.5', '10.6', '11.0', '11.1', '11.2', '11.3']
         module: ['factory_lollipop']
         experimental: [ false ]
-        include:
-          - drupal_version: '10.6'
-            module: 'factory_lollipop'
-            experimental: true
-          - drupal_version: '11.2'
-            module: 'factory_lollipop'
-            experimental: true
-          - drupal_version: '11.3'
-            module: 'factory_lollipop'
-            experimental: true
+#         include:
+#           - drupal_version: '10.6'
+#             module: 'factory_lollipop'
+#             experimental: true
+#           - drupal_version: '11.2'
+#             module: 'factory_lollipop'
+#             experimental: true
+#           - drupal_version: '11.3'
+#             module: 'factory_lollipop'
+#             experimental: true
 
     steps:
       - uses: actions/checkout@v6
@@ -88,7 +88,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5']
+        drupal_version: ['10.6']
         module: ['factory_lollipop']
 
     steps:

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2
       - uses: actions/checkout@v6
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2, phpmd
       - uses: actions/checkout@v6
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2, phpcpd
       - uses: actions/checkout@v6

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ include:
 variables:
   SKIP_ESLINT: '1'
   # Opt in to testing current minor against max supported PHP version.
-  OPT_IN_TEST_MAX_PHP: '1'
+  OPT_IN_TEST_MAX_PHP: '0' # Disable since Paragraphs (dependency) cannot run on PHP 8.5 for now.
   # Opt in to testing previous minor (Drupal 11.1.x)
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
   # Opt in to testing next minor (Drupal 11.3.x).
@@ -39,7 +39,7 @@ variables:
   # Opt in to testing $CORE_PREVIOUS_MAJOR (Drupal 10.4.x).
   OPT_IN_TEST_PREVIOUS_MAJOR: '1'
   # Opt in to testing $CORE_MAJOR_DEVELOPMENT (Drupal 12).
-  OPT_IN_TEST_NEXT_MAJOR: '1'
+  OPT_IN_TEST_NEXT_MAJOR: '0' # Disable since Paragraphs (dependency) cannot run on Drupal 12 for now.
 
 # This module wants to strictly comply with Drupal's coding standards.
 phpcs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ include:
 variables:
   SKIP_ESLINT: '1'
   # Opt in to testing current minor against max supported PHP version.
-  OPT_IN_TEST_MAX_PHP: '0' # Disable since Paragraphs (dependency) cannot run on PHP 8.5 for now.
+  OPT_IN_TEST_MAX_PHP: '1'
   # Opt in to testing previous minor (Drupal 11.1.x)
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
   # Opt in to testing next minor (Drupal 11.3.x).
@@ -39,7 +39,7 @@ variables:
   # Opt in to testing $CORE_PREVIOUS_MAJOR (Drupal 10.4.x).
   OPT_IN_TEST_PREVIOUS_MAJOR: '1'
   # Opt in to testing $CORE_MAJOR_DEVELOPMENT (Drupal 12).
-  OPT_IN_TEST_NEXT_MAJOR: '0' # Disable since Paragraphs (dependency) cannot run on Drupal 12 for now.
+  OPT_IN_TEST_NEXT_MAJOR: '0'
 
 # This module wants to strictly comply with Drupal's coding standards.
 phpcs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add official support of drupal 10.6
+- add official support of drupal 11.3
 
 ## [1.2.4] - 2025-11-07
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ on your environment:
 
 Once run, you will be able to access to your fresh installed Drupal on `localhost::8888`.
 
-    docker-compose build --pull --build-arg BASE_IMAGE_TAG=11.2 drupal
+    docker-compose build --pull --build-arg BASE_IMAGE_TAG=11.3 drupal
     # (get a coffee, this will take some time...)
     docker compose up -d drupal
     docker compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
@@ -58,7 +58,7 @@ Run testing by stopping at first failure using the following command:
 
 During Docker build, the following Static Analyzers will be installed on the Docker `drupal` via Composer:
 
-- `drupal/coder^8.3.1`  (including `squizlabs/php_codesniffer` & `phpstan/phpstan`),
+- `drupal/coder:^8.3.1`  (including `squizlabs/php_codesniffer` & `phpstan/phpstan`),
 
 The following Analyzer will be downloaded & installed as PHAR:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_TAG=11.2
+ARG BASE_IMAGE_TAG=11.3
 FROM wengerk/drupal-for-contrib:${BASE_IMAGE_TAG}
 
 ARG BASE_IMAGE_TAG
@@ -10,10 +10,10 @@ ENV SYMFONY_DEPRECATIONS_HELPER=disabled
 
 # Install drupal/paragraphs as required by entity_to_text_paragraphs
 RUN COMPOSER_MEMORY_LIMIT=-1 composer config minimum-stability dev
-RUN COMPOSER_MEMORY_LIMIT=-1 composer require "drupal/paragraphs:^1.14"
+RUN COMPOSER_MEMORY_LIMIT=-1 composer require "drupal/paragraphs:dev-1.x"
 RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev "drupal/entity_browser"
 RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev "drupal/feeds"
-RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev "drupal/pathauto"
+RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev "drupal/pathauto:dev-1.x"
 
 # Register the Drupal and DrupalPractice Standard with PHPCS.
 RUN ./vendor/bin/phpcs --config-set installed_paths \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV BASE_IMAGE_TAG=${BASE_IMAGE_TAG}
 
 # Disable deprecation notice since PHPUnit 10 with Drupal 10.2 and upper.
 # @see https://www.drupal.org/project/drupal/issues/3401236#comment-15330177
-ENV SYMFONY_DEPRECATIONS_HELPER=weak
+ENV SYMFONY_DEPRECATIONS_HELPER=disabled
 
 # Install drupal/paragraphs as required by entity_to_text_paragraphs
 RUN COMPOSER_MEMORY_LIMIT=-1 composer config minimum-stability dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV BASE_IMAGE_TAG=${BASE_IMAGE_TAG}
 
 # Disable deprecation notice since PHPUnit 10 with Drupal 10.2 and upper.
 # @see https://www.drupal.org/project/drupal/issues/3401236#comment-15330177
-ENV SYMFONY_DEPRECATIONS_HELPER=disabled
+ENV SYMFONY_DEPRECATIONS_HELPER=weak
 
 # Install drupal/paragraphs as required by entity_to_text_paragraphs
 RUN COMPOSER_MEMORY_LIMIT=-1 composer config minimum-stability dev

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,9 @@
   },
   "license": "GPL-2.0-or-later",
   "require-dev": {
-    "drupal/paragraphs": "^1",
-    "drupal/coder": "^8.3.1"
+    "drupal/paragraphs": "dev-1.x",
+    "drupal/coder": "^8.3.1",
+    "drupal/pathauto": "dev-1.x"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
   },
   "config": {
     "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "drupal/core-composer-scaffold": true
     }
   }
 }

--- a/modules/factory_lollipop_paragraphs/tests/src/Kernel/FactoryType/ParagraphFactoryTypeTest.php
+++ b/modules/factory_lollipop_paragraphs/tests/src/Kernel/FactoryType/ParagraphFactoryTypeTest.php
@@ -28,7 +28,6 @@ class ParagraphFactoryTypeTest extends EntityKernelTestBase {
     parent::setUp();
 
     $this->installEntitySchema('paragraph');
-    \Drupal::moduleHandler()->loadInclude('paragraphs', 'install');
 
     $this->paragraphFactoryTypeResolver = new ParagraphFactoryType();
     $this->paragraphFactoryTypeResolver->setEntityTypeManager($this->container->get('entity_type.manager'));

--- a/modules/factory_lollipop_paragraphs/tests/src/Kernel/FactoryType/ParagraphFactoryTypeTest.php
+++ b/modules/factory_lollipop_paragraphs/tests/src/Kernel/FactoryType/ParagraphFactoryTypeTest.php
@@ -28,6 +28,7 @@ class ParagraphFactoryTypeTest extends EntityKernelTestBase {
     parent::setUp();
 
     $this->installEntitySchema('paragraph');
+    \Drupal::moduleHandler()->loadInclude('paragraphs', 'install');
 
     $this->paragraphFactoryTypeResolver = new ParagraphFactoryType();
     $this->paragraphFactoryTypeResolver->setEntityTypeManager($this->container->get('entity_type.manager'));
@@ -38,6 +39,7 @@ class ParagraphFactoryTypeTest extends EntityKernelTestBase {
    */
   protected static $modules = [
     'paragraphs',
+    'entity_reference_revisions',
     'file',
   ];
 

--- a/modules/factory_lollipop_paragraphs/tests/src/Kernel/FactoryType/ParagraphTypeFactoryTypeTest.php
+++ b/modules/factory_lollipop_paragraphs/tests/src/Kernel/FactoryType/ParagraphTypeFactoryTypeTest.php
@@ -35,6 +35,7 @@ class ParagraphTypeFactoryTypeTest extends EntityKernelTestBase {
    */
   protected static $modules = [
     'paragraphs',
+    'entity_reference_revisions',
     'file',
   ];
 


### PR DESCRIPTION
### 💬 Description
add official support of drupal 10.6 & 11.3

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
